### PR TITLE
add extra option to allow deletion of objects. add snapshots to filter list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# Mac DS_Store files
+.DS_Store

--- a/objectApprover/object-approver-body.html
+++ b/objectApprover/object-approver-body.html
@@ -12,6 +12,9 @@
                 ng-click="model.toggleStories()">Stories</button>
             <button class="lui-button lui-button--inverse object-buttons lui-button--large" ng-class="model.showBookmarks ? 'lui-button lui-button--inverse btnActive object-buttons lui-button--large' : 'lui-button lui-button--inverse object-buttons lui-button--large'"
                 ng-click="model.toggleBookmarks()">Bookmarks</button>
+            <!-- Websy. New button to toggle snapshots on and off -->
+            <button class="lui-button lui-button--inverse object-buttons lui-button--large" ng-class="model.showSnapshots ? 'lui-button lui-button--inverse btnActive object-buttons lui-button--large' : 'lui-button lui-button--inverse object-buttons lui-button--large'"
+                ng-click="model.toggleSnapshots()">Snapshots</button>
             <button class="lui-button lui-button--inverse object-buttons lui-button--large" ng-class="model.showDimensions ? 'lui-button lui-button--inverse btnActive object-buttons lui-button--large' : 'lui-button lui-button--inverse object-buttons lui-button--large'"
                 ng-click="model.toggleDimensions()">Dimensions</button>
             <button class="lui-button lui-button--inverse object-buttons lui-button--large" ng-class="model.showMeasures ? 'lui-button lui-button--inverse btnActive object-buttons lui-button--large' : 'lui-button lui-button--inverse object-buttons lui-button--large'"
@@ -40,7 +43,7 @@
                     <col style="width:85px;min-width:85px;max-width:85px;">
                     <col style="width:150px;min-width:100px;max-width:200px;">
                     <col style="width:100px;min-width:100px;max-width:150px;">
-                    <col style="width:100px;min-width:100px;max-width:150px;">
+                    <col style="width:100px;min-width:100px;max-width:100px;">
                     <col style="width:100px;min-width:100px;max-width:100px;">
                     <col style="width:100px;min-width:100px;max-width:100px;">
                     <col style="width:100px;min-width:150px;max-width:150px;">
@@ -79,6 +82,8 @@
     <div id="button-bar">
         <button id="buttonapprove" class="lui-button" ng-class="model.approveButtonValid() ? 'lui-button--toolbar-inverse' : 'lui-disabled'" ng-click="model.approve()">Approve Object</button>
         <button id="buttonunapprove" class="lui-button" ng-class="model.unapproveButtonValid() ? 'lui-button--toolbar-inverse' : 'lui-disabled'" ng-click="model.unapprove()">Un-Approve Object</button>
+        <!-- Websy. New button to delete objects -->
+        <button id="buttondelete" class="lui-button" ng-class="model.outputs.length==0?'lui-disabled':'lui-button--toolbar-inverse'" ng-click="model.confirmDelete()">Delete Selected</button>
     </div>
 </div>
 
@@ -91,6 +96,24 @@
             </div>
 
         </div>
+
+    </div>
+</div>
+<!-- Websy. New popup dialog to confirm deletion of objects -->
+<div class="frame" style="position: fixed;top:0px;left:0px;bottom:0px;right:0px;overflow-y: auto; " ng-show="model.showConfirmDelete">
+    <div class="overlay" style="opacity: 1;">
+      <div class="lui-dialog  lui-dialog--inverse" style="width: 400px;  top: 200px;">
+        <div class="lui-dialog__header">
+          <div class="lui-dialog__title">Delete Selected Items</div>
+        </div>
+        <div class="lui-dialog__body">
+          Are you sure you want to delete the selected items? This action cannot be undone.
+        </div>
+        <div class="lui-dialog__footer">
+          <button class="lui-button  lui-dialog__button  lui-button--inverse" ng-click="model.cancelDelete()">Cancel</button>
+          <button class="lui-button  lui-dialog__button  lui-button--inverse  close-button" ng-click="model.deleteItems()">Delete</button>
+        </div>
+      </div>
 
     </div>
 </div>

--- a/objectApprover/objectapprover.component.js
+++ b/objectApprover/objectapprover.component.js
@@ -43,6 +43,14 @@
             });
     }
 
+    //Websy addition. Function to delete objects
+    function deleteObjects($http, objectIds) {
+        return $http.post("./objectapprover/delete", objectIds)
+            .then(function(response) {
+                return response;
+            })
+    }
+
     function objectBodyController($scope, $http, ngDialog, qmcuWindowLocationService) {
         var model = this;
         var colNames = [];
@@ -56,6 +64,7 @@
         model.showDimensions = false;
         model.showMeasures = false;
         model.showMasterObjects = false;
+        model.showConfirmDelete = false;
         model.modal = false;
         model.host = qmcuWindowLocationService.host;
 
@@ -88,6 +97,7 @@
         model.tableArrayOps = function(type, show) {
             model.modal = true;
             var resultArray = model.tableRows;
+            console.log(resultArray);
             if (show) {
                 fetchTableRows($http, type).then(function(response) {
                     for (var index = 0; index < response.rows.length; index++) {
@@ -135,6 +145,18 @@
                 model.showBookmarks = false;
             }
             model.tableArrayOps('bookmark', model.showBookmarks);
+
+        }
+
+        // Websy. New function to toggleSnapshots on and off
+        model.toggleSnapshots = function() {
+
+            if (!model.showSnapshots) {
+                model.showSnapshots = true;
+            } else {
+                model.showSnapshots = false;
+            }
+            model.tableArrayOps('snapshot', model.showSnapshots);
 
         }
 
@@ -299,7 +321,46 @@
                 scope: $scope
             });
         };
+
+        model.confirmDelete = function(){
+          model.showConfirmDelete = true;
+        }
+
+        model.cancelDelete = function(){
+          model.showConfirmDelete = false;
+        }
+
+        model.deleteItems = function(){
+          var objectsToDelete = [];
+          model.outputs.forEach(function(item) {
+            objectsToDelete.push(item.objectId);
+          })
+
+          if (objectsToDelete.length > 0) {
+              deleteObjects($http, objectsToDelete)
+                  .then(function(result) {
+                      for (var i = 0; i < objectsToDelete.length; i++) {
+                        deleteObjectById(objectsToDelete[i])
+                      }
+                      console.log(result);
+                      $scope.form.$setPristine();
+                      $scope.form.$setUntouched();
+                  });
+          }
+          model.showConfirmDelete = false;
+
+          function deleteObjectById(id){
+            for (var i = 0; i < model.tableRows.length; i++) {
+              if(model.tableRows[i][model.tableRows[i].length-1]==id){
+                model.tableRows.splice(i, 1)
+                return true;
+              }
+            }
+            return false;
+          }
+        }
     }
+
 
     module.component("objectApproverBody", {
         transclude: true,

--- a/objectApprover/routes.js
+++ b/objectApprover/routes.js
@@ -117,6 +117,30 @@ router.route('/publish/:publishcommand')
             });
     });
 
+// Websy. New route to handle object deletions
+router.route('/delete')
+    .post(parseUrlencoded, function(request, response) {
+        console.log("delete");
+        Promise.all(request.body.map(function(objectId) {
+                return qrs.Delete('app/object/' + objectId)
+                    .then(function(result) {
+                        message.success = true;
+                        message.result = result;
+                        return message;
+                    })
+                    .catch(function(error) {
+                        return error;
+                        // response.send(error);
+                    });
+            }))
+            .then(function(resultArray) {
+                response.send(resultArray);
+            })
+            .catch(function(error) {
+                response.send(error)
+            });
+    });
+
 router.route('/approveSheets')
     .post(parseUrlencoded, function(request, response) {
         console.log("approveSheets");


### PR DESCRIPTION
We had a request from a client to be able to manage snapshots and bookmarks. They're already using the QMC Utilities so I thought it made sense to add it to the tool instead of re-inventing the wheel. I've added a delete option to the object approver and included 'Snapshots' in the filter button list. Any objections or issues, let me know.